### PR TITLE
GHC 927 Upgrade

### DIFF
--- a/bench/cereal-bench.cabal
+++ b/bench/cereal-bench.cabal
@@ -19,6 +19,7 @@ executable cereal-bench
   main-is:           Benchmark.hs
   hs-source-dirs:    src .
   build-depends:     base
+                     , aeson
                      , cereal
                      , containers >= 0.5
                      , array      >= 0.3

--- a/src/Data/Serialize.hs
+++ b/src/Data/Serialize.hs
@@ -80,6 +80,8 @@ import qualified Data.Ratio            as R
 import qualified Data.Tree             as T
 import qualified Data.Sequence         as Seq
 
+import qualified Data.Aeson.KeyMap     as AKM
+import qualified Data.Aeson.Key        as AKey
 import GHC.Generics
 
 #if !(MIN_VERSION_base(4,8,0))
@@ -777,3 +779,11 @@ instance Serialize UTCTime where
     day <- get
     d <- get
     pure $ UTCTime (ModifiedJulianDay day) (picosecondsToDiffTime d)
+
+instance (Serialize v) => Serialize (AKM.KeyMap v) where
+    put = putKeyMapOf put put
+    get = getKeyMapOf get get
+
+instance Serialize AKey.Key where
+  put = put . AKey.toText
+  get = AKey.fromText <$> get

--- a/src/Data/Serialize/Get.hs
+++ b/src/Data/Serialize/Get.hs
@@ -94,6 +94,7 @@ module Data.Serialize.Get (
     , getMapOf
     , getIntMapOf
     , getHashMapOf
+    , getKeyMapOf
     , getSetOf
     , getIntSetOf
     , getMaybeOf
@@ -101,6 +102,9 @@ module Data.Serialize.Get (
     , getEitherOf
     , getNested
   ) where
+
+import qualified Data.Aeson.KeyMap as AKM
+import qualified Data.Aeson.Key as AKey
 
 import qualified Control.Applicative as A
 import qualified Control.Monad as M
@@ -827,6 +831,10 @@ getIntMapOf i m = IntMap.fromList `fmap` getListOf (getTwoOf i m)
 -- | Read as a list of pairs of key and element.
 getHashMapOf :: Eq k => Hashable k => Get k -> Get a -> Get (HashMap.HashMap k a)
 getHashMapOf k m = HashMap.fromList `fmap` getListOf (getTwoOf k m)
+
+-- | Read as a list of pairs of key and element.
+getKeyMapOf :: Get AKey.Key -> Get v -> Get (AKM.KeyMap v)
+getKeyMapOf k m = AKM.fromList `fmap` getListOf (getTwoOf k m)
 
 -- | Read as a list of elements.
 getSetOf :: Ord a => Get a -> Get (Set.Set a)

--- a/src/Data/Serialize/Put.hs
+++ b/src/Data/Serialize/Put.hs
@@ -84,6 +84,7 @@ module Data.Serialize.Put (
     , putMapOf
     , putIntMapOf
     , putHashMapOf
+    , putKeyMapOf
     , putSetOf
     , putIntSetOf
     , putMaybeOf
@@ -93,6 +94,8 @@ module Data.Serialize.Put (
   ) where
 
 
+import qualified Data.Aeson.KeyMap as AKM
+import qualified Data.Aeson.Key as AKey
 import           Data.ByteString.Builder (Builder, toLazyByteString)
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Builder.Extra as B
@@ -447,6 +450,10 @@ putIntMapOf pix pa = putListOf (putTwoOf pix pa) . IntMap.toAscList
 putHashMapOf :: Putter k -> Putter a -> Putter (HashMap.HashMap k a)
 putHashMapOf pk pa = putListOf (putTwoOf pk pa) . HashMap.toList
 {-# INLINE putHashMapOf #-}
+
+putKeyMapOf :: Putter AKey.Key -> Putter v -> Putter (AKM.KeyMap v)
+putKeyMapOf pk pa = putListOf (putTwoOf pk pa) . AKM.toList
+{-# INLINE putKeyMapOf #-}
 
 putSetOf :: Putter a -> Putter (Set.Set a)
 putSetOf pa = putListOf pa . Set.toAscList

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-16.16
+resolver: lts-20.24
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 532380
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/16.yaml
-    sha256: d6b004b095fe2a0b8b14fbc30014ee97e58843b9c9362ddb9244273dda62649e
-  original: lts-16.16
+    sha256: e019cd29e3f7f9dbad500225829a3f7a50f73c674614f2f452e21bb8bf5d99ea
+    size: 650253
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/24.yaml
+  original: lts-20.24

--- a/tests/RoundTrip.hs
+++ b/tests/RoundTrip.hs
@@ -23,6 +23,7 @@ import Test.QuickCheck as QC
 import Data.Time
 import qualified Data.Aeson as A
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson.KeyMap as AKM
 import Data.Cereal.Instances ()
 
 import Test.Framework (Test(),testGroup)
@@ -72,7 +73,7 @@ tests  = testGroup "Round Trip"
   , testProperty "Value with String Round Trip "
     $ roundTrip put get (A.String "abc")
   , testProperty "Value with Object Round Trip "
-    $ roundTrip put get (A.Object $ HM.insert "abc" (A.String "abc") HM.empty)
+    $ roundTrip put get (A.Object $ AKM.insert "abc" (A.String "abc") AKM.empty)
   ]
 
 timeTests :: LocalTime -> UTCTime -> Test


### PR DESCRIPTION
This PR enables the project to build with `GHC 9.2.7` and related updated package set.

Key changes include:

1. Stack resolver update - use new lts-20.24 stack resolver (GHC 9.2.7)
2. Adds support for Aeson V2+ breaking changes
3. Adds `Serialize` instances for new `Aeson.KeyMap` and `Aeson.Key` types
4. Fix test-suite.
5. Minor refactoring here and there.